### PR TITLE
feat(policy): use new major version of the apiKey policy

### DIFF
--- a/release.json
+++ b/release.json
@@ -42,7 +42,7 @@
         },
         {
             "name": "gravitee-policy-apikey",
-            "version": "1.8.0"
+            "version": "2.0.0-SNAPSHOT"
         },
         {
             "name": "gravitee-policy-ratelimit",

--- a/upgrades/3.0.0/README.adoc
+++ b/upgrades/3.0.0/README.adoc
@@ -15,6 +15,10 @@ It will allow you to manage more than one environment for each instance of Gravi
 If you are using the REST API directly, please note that you will have to adapt the URL
 from `https://host/management/` to `https://host/management/DEFAULT/`
 
+== Breaking Changes
+=== API-Key policy
+In this new version, if api-keys used to call an API is invalid or has expired, the gateway will fail with a *401* (instead of 403 in previous versions of Gravitee).
+
 == Repository
 === Mongodb
 


### PR DESCRIPTION
This is a breaking change for API customers
Closes gravitee-io/issues#2842