### PR TITLE
feat(json-validation): configure json-validation policy on API creation

### DIFF
--- a/release.json
+++ b/release.json
@@ -247,7 +247,7 @@
         },
         {
             "name": "gravitee-policy-json-validation",
-            "version": "1.4.0"
+            "version": "1.5.0-SNAPSHOT"
         },
         {
             "name": "gravitee-reporter-kafka",


### PR DESCRIPTION
If API is created with openAPI of Swagger, user can choose to configure a json-validation policy.

Closes gravitee-io/issues#4293