### PR TITLE
feat(xml-validation): configure xml-validation policy on API creation

### DIFF
--- a/release.json
+++ b/release.json
@@ -250,6 +250,10 @@
             "version": "1.4.0"
         },
         {
+            "name": "gravitee-policy-xml-validation",
+            "version": "1.0.0-SNAPSHOT"
+        },
+        {
             "name": "gravitee-reporter-kafka",
             "version": "1.2.0"
         },
@@ -385,6 +389,7 @@
             "gravitee-policy-jws",
             "gravitee-policy-url-rewriting",
             "gravitee-policy-json-validation",
+            "gravitee-policy-xml-validation",
             "gravitee-policy-callout-http",
             "gravitee-policy-generate-jwt",
             "gravitee-policy-assign-attributes",


### PR DESCRIPTION
If API is created with openAPI of Swagger, user can choose to configure a xml-validation policy.

Closes gravitee-io/issues#4294