### PR TITLE
fix(ES reporter): do not index headers to avoid too many field error

### DIFF
--- a/release.json
+++ b/release.json
@@ -171,7 +171,7 @@
         },
         {
             "name": "gravitee-elasticsearch",
-            "version": "1.30.16"
+            "version": "1.30.17-SNAPSHOT"
         },
         {
             "name": "gravitee-repository-jdbc",


### PR DESCRIPTION
Fixe gravitee-io/issues#4566