### PR TITLE
feat: auto-enable geoip and user_agent when elasticsearch > 7.x

### DIFF
--- a/upgrades/3.x/3.6.0/README.adoc
+++ b/upgrades/3.x/3.6.0/README.adoc
@@ -1,0 +1,6 @@
+= Upgrade to 3.6.0
+
+=== Elasticsearch
+
+With Elasticsearch version above 7.x, `geoip` and `user_agent` plugins are automatically enabled.
+


### PR DESCRIPTION
Fixes https://github.com/gravitee-io/issues/issues/4744