### PR TITLE
fix: rest-to-soap do not override request path info

### DIFF
--- a/release.json
+++ b/release.json
@@ -15,7 +15,7 @@
         },
         {
             "name": "gravitee-gateway",
-            "version": "3.5.1"
+            "version": "3.5.2-SNAPSHOT"
         },
         {
             "name": "gravitee-gateway-api",
@@ -67,7 +67,7 @@
         },
         {
             "name": "gravitee-policy-rest-to-soap",
-            "version": "1.10.0"
+            "version": "1.10.1-SNAPSHOT"
         },
         {
             "name": "gravitee-policy-transformqueryparams",


### PR DESCRIPTION
Fixes gravitee-io/issues#4860