### PR TITLE
feat(reporter): Expose timestamp to JSON formatter so it gets includeExpose timestamp to JSON formatter so it gets included in File Reporter

### DIFF
--- a/release.json
+++ b/release.json
@@ -155,7 +155,7 @@
         },
         {
             "name": "gravitee-reporter-api",
-            "version": "1.19.0"
+            "version": "1.20.0-SNAPSHOT"
         },
         {
             "name": "gravitee-reporter-file",


### PR DESCRIPTION
Closes gravitee-io/issues#5097