### PR TITLE
chore: bump gravitee-cockpit-connectors-ws to 1.0.1

### DIFF
--- a/release.json
+++ b/release.json
@@ -351,7 +351,7 @@
         },
         {
             "name": "gravitee-cockpit-connectors-ws",
-            "version": "1.0.0"
+            "version": "1.0.1"
         }
     ],
     "buildDependencies": [


### PR DESCRIPTION
fix gravitee-io/issues#5392