### PR TITLE
fix: Default Schema is now set to "public" for jdbc

### DIFF
--- a/release.json
+++ b/release.json
@@ -206,7 +206,7 @@
         },
         {
             "name": "gravitee-repository-jdbc",
-            "version": "3.7.1",
+            "version": "3.7.2-SNAPSHOT",
             "since": "3.7.1"
         },
         {


### PR DESCRIPTION
Closes gravitee-io/issues#5468