### PR TITLE
fix: Default Schema is now set to public for jdbc

### DIFF
--- a/release.json
+++ b/release.json
@@ -183,7 +183,7 @@
         },
         {
             "name": "gravitee-repository-jdbc",
-            "version": "3.0.11",
+            "version": "3.0.12-SNAPSHOT",
             "since": "3.0.16"
         },
         {


### PR DESCRIPTION
Closes gravitee-io/issues#5503