### PR TITLE
chore: add note about AE connector into the APIM 3.9.2 migration guide

### DIFF
--- a/upgrades/3.x/3.9.2/README.adoc
+++ b/upgrades/3.x/3.9.2/README.adoc
@@ -1,0 +1,6 @@
+= Upgrade to 3.9.2
+
+== Important: Alert Engine 
+
+NOTE: For users of Gravitee Enterprise Edition with Alert Engine, please check your gravitee configuration to ensure that the alert engine feature is explictly enable. Starting from this version, the alert engine connector is disabled by default if the option `alerts.alert-engine-enabled` is missing from the gravitee.yaml. (see https://docs.gravitee.io/ae/apim_installation.html#configuration)
+

--- a/upgrades/3.x/README.adoc
+++ b/upgrades/3.x/README.adoc
@@ -1,6 +1,9 @@
 = Upgrade Notes
 
 ifdef::env-github[]
+
+include::3.9.2/README.adoc[leveloffset=+1]
+
 include::3.9.0/README.adoc[leveloffset=+1]
 
 include::3.8.0/README.adoc[leveloffset=+1]
@@ -39,6 +42,8 @@ You may be required to perform manual actions as part of the upgrade.
 
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
+
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.9.2/README.adoc[leveloffset=+1]
 
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.9.0/README.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Fixes gravitee-io/issues#5777