### PR TITLE
chore(version): bump gravitee-node version to 1.12.1-SNAPSHOT

### DIFF
--- a/release.json
+++ b/release.json
@@ -293,7 +293,7 @@
         },
         {
             "name": "graviteeio-node",
-            "version": "1.12.0",
+            "version": "1.12.1-SNAPSHOT",
             "since": "3.7.0"
         },
         {


### PR DESCRIPTION
Related to gravitee-io/issues#5764