### PR TITLE
Check `release.json` validity in CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,15 +45,15 @@ orbs:
   slack: circleci/slack@4.4.0
 
 jobs:
-  empty_job:
+  check-releasejson:
     docker:
-     - image: alpine
+      - image: cimg/node:lts
     resource_class: small
-    working_directory: /mnt/ramdisk
     steps:
+      - checkout
       - run:
-          name: "This is a blank job"
-          command: echo "No task is executed."
+          name: Check if `release.json` is a valid JSON file
+          command: npx jsonlint release.json
 
   bom_to_slack:
     machine:
@@ -301,11 +301,11 @@ jobs:
 workflows:
   version: 2.1
   # Blank process invoked when pull requests events are triggered
-  blank:
+  validate:
     when:
       equal: [ blank, << pipeline.parameters.gio_action >> ]
     jobs:
-      - empty_job:
+      - check-releasejson:
           context: cicd-orchestrator
   dry_release_process:
     when:


### PR DESCRIPTION
**Description**

To avoid having a malformed JSON in `release.json` file I added a simple CI job to check the file is a valid JSON file.

Example: 
https://app.circleci.com/pipelines/github/gravitee-io/release/1740/workflows/0afa9ed0-95a0-47d4-a2fd-90610955e0d8

![image](https://user-images.githubusercontent.com/4112568/127159678-5d28722a-d19a-4906-acd7-a462ddf8cc1a.png)
![image](https://user-images.githubusercontent.com/4112568/127159688-cc209112-d4e7-44fd-b601-8248d5ba50ec.png)
