### PR TITLE
fix: bump versions for opentracing

### DIFF
--- a/release.json
+++ b/release.json
@@ -26,7 +26,7 @@
         },
         {
             "name": "gravitee-gateway-api",
-            "version": "1.26.0",
+            "version": "1.26.1-SNAPSHOT",
             "since": "3.8.0"
         },
         {
@@ -269,7 +269,7 @@
         },
         {
             "name": "graviteeio-node",
-            "version": "1.15.1",
+            "version": "1.16.0-SNAPSHOT",
             "since": "3.9.2"
         },
         {


### PR DESCRIPTION
* gateway-api to 1.26.1-SNAPSHOT
* graviteeio-node to 1.16.0-SNAPSHOT