### PR TITLE
chore: bump policy-metrics-reporter to 1.1.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -176,7 +176,7 @@
         },
         {
             "name": "gravitee-policy-metrics-reporter",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "since": "3.9.0"
         },
         {


### PR DESCRIPTION
https://github.com/gravitee-io/gravitee-policy-metrics-reporter/releases/tag/1.1.0