### PR TITLE
Adding missing documentation

### DIFF
--- a/upgrades/3.x/3.10.1/README.adoc
+++ b/upgrades/3.x/3.10.1/README.adoc
@@ -1,0 +1,13 @@
+= Upgrade to 3.10.1
+
+== Breaking changes
+
+From with this version, the name of the APIM Rest APIs component changes.
+As a consequence:
+
+1. The APIM Rest API component available on https://download.gravitee.io is now `gravitee-*apim*-rest-api-x.y.z.zip` instead of `gravitee-management-rest-api-x.y.z.zip`
+
+2. The name of the APIM Rest API folder within the full distribution zip file (graviteeio-full-x.y.z.zip) is now `graviteeio-*apim*-rest-api-x.y.z` instead of `graviteeio-rest-api-x.y.z`
+
+
+WARNING: In future versions, others plugins & components might be renamed. Stay tuned!

--- a/upgrades/3.x/3.9.4/README.adoc
+++ b/upgrades/3.x/3.9.4/README.adoc
@@ -2,8 +2,20 @@
 
 == Breaking changes
 
+=== Threat protection policies
 From this version, configuration form for JSON Threat Protection Policy and XML Threat Protection Policy changes:
 `null` is no longer authorized, only `-1` is accepted for a 'no limit' setting.
+
+
+=== Management Rest API
+From with this version, the name of the APIM Rest APIs component changes.
+As a consequence:
+
+1. The APIM Rest API component available on https://download.gravitee.io is now `gravitee-*apim*-rest-api-x.y.z.zip` instead of `gravitee-management-rest-api-x.y.z.zip`
+
+2. The name of the APIM Rest API folder within the full distribution zip file (graviteeio-full-x.y.z.zip) is now `graviteeio-*apim*-rest-api-x.y.z` instead of `graviteeio-rest-api-x.y.z`
+
+WARNING: In future versions, others plugins & components might be renamed. Stay tuned!
 
 === Impacts
 

--- a/upgrades/3.x/README.adoc
+++ b/upgrades/3.x/README.adoc
@@ -1,10 +1,9 @@
 = Upgrade Notes
 
 ifdef::env-github[]
-
-include::3.12.0/README.adoc[leveloffset=+1]
-
 include::3.11.0/README.adoc[leveloffset=+1]
+
+include::3.10.1/README.adoc[leveloffset=+1]
 
 include::3.10.0/README.adoc[leveloffset=+1]
 
@@ -61,7 +60,13 @@ You may be required to perform manual actions as part of the upgrade.
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
 
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.11.0/README.adoc[leveloffset=+1]
+
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.10.1/README.adoc[leveloffset=+1]
+
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.10.0/README.adoc[leveloffset=+1]
+
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.9.4/README.adoc[leveloffset=+1]
 
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.9.3/README.adoc[leveloffset=+1]
 


### PR DESCRIPTION
and removing 3.12.0 link since it should be displayed only after the release

gravitee-io/issues#6029