### PR TITLE
adding link to 3.12.0 upgrade guide

### DIFF
--- a/upgrades/3.x/README.adoc
+++ b/upgrades/3.x/README.adoc
@@ -1,6 +1,8 @@
 = Upgrade Notes
 
 ifdef::env-github[]
+include::3.12.0/README.adoc[leveloffset=+1]
+
 include::3.11.1/README.adoc[leveloffset=+1]
 
 include::3.11.0/README.adoc[leveloffset=+1]
@@ -61,6 +63,10 @@ You may be required to perform manual actions as part of the upgrade.
 
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
+
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.12.0/README.adoc[leveloffset=+1]
+
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.11.1/README.adoc[leveloffset=+1]
 
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.11.0/README.adoc[leveloffset=+1]
 


### PR DESCRIPTION
⚠️ Wait for the 3.12.0 to be released before rebasing and merging this PR ⚠️ 

gravitee-io/issues#6029