### PR TITLE
fix: bump versions of resource-oauth2-providers-xxx

### DIFF
--- a/release.json
+++ b/release.json
@@ -17,12 +17,12 @@
         },
         {
             "name": "gravitee-api-management",
-            "version": "3.10.1",
+            "version": "3.10.2-SNAPSHOT",
             "since": "3.10.1"
         },
         {
             "name": "gravitee-gateway",
-            "version": "3.10.1",
+            "version": "3.10.2-SNAPSHOT",
             "since": "3.10.1"
         },
         {
@@ -32,12 +32,12 @@
         },
         {
             "name": "gravitee-management-webui",
-            "version": "3.10.1",
+            "version": "3.10.2-SNAPSHOT",
             "since": "3.10.1"
         },
         {
             "name": "gravitee-portal-webui",
-            "version": "3.10.1",
+            "version": "3.10.2-SNAPSHOT",
             "since": "3.10.1"
         },
         {

--- a/release.json
+++ b/release.json
@@ -214,17 +214,17 @@
         },
         {
             "name": "gravitee-resource-oauth2-provider-generic",
-            "version": "1.16.0",
+            "version": "1.16.1",
             "since": "3.10.0"
         },
         {
             "name": "gravitee-resource-oauth2-provider-am",
-            "version": "1.14.0",
+            "version": "1.14.1",
             "since": "3.10.0"
         },
         {
             "name": "gravitee-resource-oauth2-provider-keycloak",
-            "version": "1.9.0",
+            "version": "1.9.1",
             "since": "3.10.0"
         },
         {


### PR DESCRIPTION
⚠️ Wait for official release of the plugins before merging this PR ⚠️ 
gravitee-io/issues#6176