### PR TITLE
chore: bump gravitee-policy-jwt to 1.21.0-SNAPSHOT in release.json

### DIFF
--- a/release.json
+++ b/release.json
@@ -122,7 +122,7 @@
         },
         {
             "name": "gravitee-policy-jwt",
-            "version": "1.20.0",
+            "version": "1.21.0-SNAPSHOT",
             "since": "3.10.0"
         },
         {


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6046

:warning: Merge after https://github.com/gravitee-io/gravitee-policy-jwt/pull/59 :warning: 