### PR TITLE
doc: add breaking change info about UIs migration into monorepo - 3.5.x

### DIFF
--- a/upgrades/3.x/3.5.21/README.adoc
+++ b/upgrades/3.x/3.5.21/README.adoc
@@ -1,0 +1,21 @@
+= Upgrade to 3.5.21
+
+== Breaking changes
+
+=== Management Web UI
+From with this version, the name of the APIM Console component changes.
+As a consequence:
+
+1. The APIM Console component available on https://download.gravitee.io is now `gravitee-*apim-console*-webui-x.y.z.zip` instead of `gravitee-management-webui-x.y.z.zip`
+
+2. The name of the APIM Console folder within the full distribution zip file (graviteeio-full-x.y.z.zip) is now `graviteeio-*apim-console*-ui-x.y.z` instead of `graviteeio-management-ui-x.y.z`
+
+=== Portal Web UI
+From with this version, the name of the APIM Portal component changes.
+As a consequence:
+
+1. The APIM Portal component available on https://download.gravitee.io is now `gravitee-*apim*-portal-webui-x.y.z.zip` instead of `gravitee-portal-webui-x.y.z.zip`
+
+2. The name of the APIM Portal folder within the full distribution zip file (graviteeio-full-x.y.z.zip) is now `graviteeio-*apim*-portal-ui-x.y.z` instead of `graviteeio-portal-ui-x.y.z`
+
+WARNING: In future versions, others plugins & components might be renamed. Stay tuned!

--- a/upgrades/3.x/README.adoc
+++ b/upgrades/3.x/README.adoc
@@ -27,6 +27,8 @@ include::3.7.0/README.adoc[leveloffset=+1]
 
 include::3.6.0/README.adoc[leveloffset=+1]
 
+include::3.5.21/README.adoc[leveloffset=+1]
+
 include::3.5.19/README.adoc[leveloffset=+1]
 
 include::3.5.18/README.adoc[leveloffset=+1]
@@ -91,6 +93,8 @@ include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.7.0/README.adoc[leveloffset=+1]
 
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.6.0/README.adoc[leveloffset=+1]
+
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.5.21/README.adoc[leveloffset=+1]
 
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.5.19/README.adoc[leveloffset=+1]
 


### PR DESCRIPTION
⚠️ Wait for the 3.5.21 release before merging this PR ⚠️ 

gravitee-io/issues#6424