### PR TITLE
doc: add breaking change info about UIs migration into monorepo - 3.10.x

### DIFF
--- a/upgrades/3.x/3.10.4/README.adoc
+++ b/upgrades/3.x/3.10.4/README.adoc
@@ -1,0 +1,21 @@
+= Upgrade to 3.10.4
+
+== Breaking changes
+
+=== Management Web UI
+From with this version, the name of the APIM Console component changes.
+As a consequence:
+
+1. The APIM Console component available on https://download.gravitee.io is now `gravitee-*apim-console*-webui-x.y.z.zip` instead of `gravitee-management-webui-x.y.z.zip`
+
+2. The name of the APIM Console folder within the full distribution zip file (graviteeio-full-x.y.z.zip) is now `graviteeio-*apim-console*-ui-x.y.z` instead of `graviteeio-management-ui-x.y.z`
+
+=== Portal Web UI
+From with this version, the name of the APIM Portal component changes.
+As a consequence:
+
+1. The APIM Portal component available on https://download.gravitee.io is now `gravitee-*apim*-portal-webui-x.y.z.zip` instead of `gravitee-portal-webui-x.y.z.zip`
+
+2. The name of the APIM Portal folder within the full distribution zip file (graviteeio-full-x.y.z.zip) is now `graviteeio-*apim*-portal-ui-x.y.z` instead of `graviteeio-portal-ui-x.y.z`
+
+WARNING: In future versions, others plugins & components might be renamed. Stay tuned!

--- a/upgrades/3.x/README.adoc
+++ b/upgrades/3.x/README.adoc
@@ -7,6 +7,8 @@ include::3.11.1/README.adoc[leveloffset=+1]
 
 include::3.11.0/README.adoc[leveloffset=+1]
 
+include::3.10.4/README.adoc[leveloffset=+1]
+
 include::3.10.1/README.adoc[leveloffset=+1]
 
 include::3.10.0/README.adoc[leveloffset=+1]
@@ -71,6 +73,8 @@ include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.11.1/README.adoc[leveloffset=+1]
 
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.11.0/README.adoc[leveloffset=+1]
+
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.10.4/README.adoc[leveloffset=+1]
 
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.10.1/README.adoc[leveloffset=+1]
 


### PR DESCRIPTION
⚠️ Wait for the 3.10.4 release before merging this PR ⚠️

gravitee-io/issues#6425