### PR TITLE
fix: bump gravitee-elasticsearch to 3.5.5-SNAPSHOT fixes ILM managed indexes on elastic reporter

### DIFF
--- a/release.json
+++ b/release.json
@@ -176,7 +176,7 @@
         },
         {
             "name": "gravitee-elasticsearch",
-            "version": "3.5.4",
+            "version": "3.5.5-SNAPSHOT",
             "since": "3.5.12"
         },
         {


### PR DESCRIPTION
:warning: don't merge before the release :warning: 

https://github.com/gravitee-io/issues/issues/6507

fix: bump gravitee-elasticsearch to 3.5.5-SNAPSHOT fixes ILM managed indexes on elastic reporter