### PR TITLE
feat: bump gravitee-elasticsearch to 3.10.0 adds opensearch support

### DIFF
--- a/release.json
+++ b/release.json
@@ -190,7 +190,7 @@
         },
         {
             "name": "gravitee-elasticsearch",
-            "version": "3.9.0",
+            "version": "3.10.0-SNAPSHOT",
             "since": "3.13.0"
         },
         {


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6423

:warning: Merge only before release :warning: 