### PR TITLE
Update release.json 3.10.x

### DIFF
--- a/release.json
+++ b/release.json
@@ -17,7 +17,7 @@
         },
         {
             "name": "gravitee-api-management",
-            "version": "3.10.7",
+            "version": "3.10.8-SNAPSHOT",
             "since": "3.10.7"
         },
         {

--- a/release.json
+++ b/release.json
@@ -27,7 +27,7 @@
         },
         {
             "name": "gravitee-gateway-api",
-            "version": "1.27.3-SNAPSHOT",
+            "version": "1.27.3",
             "since": "3.10.0"
         },
         {


### PR DESCRIPTION
* Prepares the 3.10.8 release by changing the version of `gravitee-api-management`.
* Removes "SNAPSHOT" from the `gravitee-gateway-api` since it has been released in a standalone way.