### PR TITLE
chore: bump jaeger tracer plugin to 1.0.1 version

### DIFF
--- a/release.json
+++ b/release.json
@@ -358,7 +358,7 @@
         },
         {
             "name": "gravitee-tracer-jaeger",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "since": "3.10.0"
         }
     ],


### PR DESCRIPTION
gravitee-io/issues#6366