### PR TITLE
chore: bump elasticsearch reporter version to 3.9.1-SNAPSHOT

### DIFF
--- a/release.json
+++ b/release.json
@@ -185,7 +185,7 @@
         },
         {
             "name": "gravitee-elasticsearch",
-            "version": "3.9.0",
+            "version": "3.9.1-SNAPSHOT",
             "since": "3.13.0"
         },
         {


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/6630