### PR TITLE
Bump cockpit connector ws to 2.0.1

### DIFF
--- a/release.json
+++ b/release.json
@@ -333,7 +333,7 @@
         },
         {
             "name": "gravitee-cockpit-connectors-ws",
-            "version": "2.0.0"
+            "version": "2.0.1"
         },
         {
             "name": "gravitee-policy-traffic-shadowing",


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6676

**Description**

Bump cockpit connector ws to 2.0.1 to fix issue with sharding tags: https://github.com/gravitee-io/gravitee-cockpit-connectors/commit/1172010abab3c5e746809ca51181dff54fac2a46
