### PR TITLE
feat: bump elasticsearch to 3.8.2 changes ES reporter default plugins management

### DIFF
--- a/release.json
+++ b/release.json
@@ -183,7 +183,7 @@
         },
         {
             "name": "gravitee-elasticsearch",
-            "version": "3.8.1",
+            "version": "3.8.2-SNAPSHOT",
             "since": "3.10.6"
         },
         {


### PR DESCRIPTION
:warning: merge only before releasing :warning: 

**Issue**

https://github.com/gravitee-io/issues/issues/6710

**Description**

This backports in 3.10 : #6683