### PR TITLE
docs: add 3.10.9 upgrade note about ElasticSearch reporter plugins configuration change

### DIFF
--- a/upgrades/3.x/3.10.9/README.adoc
+++ b/upgrades/3.x/3.10.9/README.adoc
@@ -1,0 +1,17 @@
+= Upgrade to 3.10.9
+
+== Elastic Search reporter plugins configuration
+
+Before Gravitee 3.10.9 :
+
+- For ES>=7, GeoIp and UserAgent plugins are enabled by default in Gravitee, and can't be disabled
+- For ES<7, those plugins are disabled by default and can be enabled in Gravitee configuration.
+
+Since Gravitee 3.10.9, it behave the same way for all ES versions :
+GeoIp and UserAgent plugins are be enabled by default, and can be disabled by overriding default `reporters.elasticsearch.pipeline.plugins.ingest` configuration.
+
+If your Gravitee configuration enables a plugin which is not available on your ES instance, you will get this kind of error message on gateway startup :
+
+`Unable to create ES pipeline 'gravitee_pipeline': status[400] response[{"error":{"root_cause":[{"reason":"No processor type exists with name [geoip]","processor_type":"geoip"}]`
+
+And then, you have to override `reporters.elasticsearch.pipeline.plugins.ingest` default configuration, to remove unrelevant plugin.

--- a/upgrades/3.x/README.adoc
+++ b/upgrades/3.x/README.adoc
@@ -15,6 +15,8 @@ include::3.11.1/README.adoc[leveloffset=+1]
 
 include::3.11.0/README.adoc[leveloffset=+1]
 
+include::3.10.9/README.adoc[leveloffset=+1]
+
 include::3.10.8/README.adoc[leveloffset=+1]
 
 include::3.10.4/README.adoc[leveloffset=+1]


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6710

**Description**

This backports in 3.10 : #6683

⚠️ merge only after releasing 3.10.9 ⚠️

