### PR TITLE
feat: bump elasticsearch version to 3.5.6 adds openSearch support

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
     "name": "Gravitee.io",
-    "version": "3.5.28",
+    "version": "3.5.29-SNAPSHOT",
     "buildTimestamp": "2021-03-11T11:31:24+0000",
     "scmSshUrl": "git@github.com:gravitee-io",
     "scmHttpUrl": "https://github.com/gravitee-io/",

--- a/release.json
+++ b/release.json
@@ -171,7 +171,7 @@
         },
         {
             "name": "gravitee-elasticsearch",
-            "version": "3.5.5",
+            "version": "3.5.6-SNAPSHOT",
             "since": "3.5.23"
         },
         {


### PR DESCRIPTION
:warning: Merge during APIM 3.5.x release :warning: 

https://github.com/gravitee-io/issues/issues/6889

This backports https://github.com/gravitee-io/issues/issues/6423 to 3.5