### PR TITLE
feat: bump elasticsearch version to 3.8.3 adds openSearch support

### DIFF
--- a/release.json
+++ b/release.json
@@ -183,7 +183,7 @@
         },
         {
             "name": "gravitee-elasticsearch",
-            "version": "3.8.2",
+            "version": "3.8.3-SNAPSHOT",
             "since": "3.10.6"
         },
         {

--- a/release.json
+++ b/release.json
@@ -1,6 +1,6 @@
 {
     "name": "Gravitee.io",
-    "version": "3.10.9",
+    "version": "3.10.10-SNAPSHOT",
     "buildTimestamp": "2021-02-17T20:55:06+0000",
     "scmSshUrl": "git@github.com:gravitee-io",
     "scmHttpUrl": "https://github.com/gravitee-io/",


### PR DESCRIPTION
:warning: Merge during APIM 3.10.x release :warning: 

https://github.com/gravitee-io/issues/issues/6890

This backports https://github.com/gravitee-io/issues/issues/6423 to 3.10