### PR TITLE
chore: update cockpit-connectors-ws to 2.3.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -349,7 +349,7 @@
         },
         {
             "name": "gravitee-cockpit-connectors-ws",
-            "version": "2.0.0"
+            "version": "2.3.0"
         },
         {
             "name": "gravitee-policy-traffic-shadowing",


### PR DESCRIPTION
**Description**

Update `gravitee-cockpit-connectors-ws` to 2.3.0. 

It looks strange to still be on 2.0.0 thought 🤔 