### PR TITLE
fix(metrics): Add support for old prometheus label names for backward compatibility

### DIFF
--- a/release.json
+++ b/release.json
@@ -266,7 +266,7 @@
         },
         {
             "name": "gravitee-node",
-            "version": "1.16.4",
+            "version": "1.16.5-SNAPSHOT",
             "since": "3.10.0"
         },
         {


### PR DESCRIPTION
gravitee-io/issues#6924