### PR TITLE
chore: use stable version of gravitee-policy-json-to-json

### DIFF
--- a/release.json
+++ b/release.json
@@ -126,7 +126,7 @@
         },
         {
             "name": "gravitee-policy-json-to-json",
-            "version": "1.7.0-SNAPSHOT"
+            "version": "1.7.0"
         },
         {
             "name": "gravitee-policy-json-xml",


### PR DESCRIPTION
As policies are now using semantic release version 1.7.0 has already been released so we can use it directly