### PR TITLE
fix: bump rest-to-soap from 1.12.0 to 1.13.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -245,7 +245,7 @@
         },
         {
             "name": "gravitee-policy-rest-to-soap",
-            "version": "1.12.0",
+            "version": "1.13.0",
             "since": "3.7.0"
         },
         {


### PR DESCRIPTION
gravitee-io/issues#7025