### PR TITLE
chore: bump policy cache version

### DIFF
--- a/release.json
+++ b/release.json
@@ -76,7 +76,7 @@
         },
         {
             "name": "gravitee-policy-cache",
-            "version": "1.13.1",
+            "version": "1.13.2-SNAPSHOT",
             "since": "3.10.0"
         },
         {


### PR DESCRIPTION
gravitee-io/issues#6967