### PR TITLE
fix: let the API Owner choose the Accept-Encoding

### DIFF
--- a/release.json
+++ b/release.json
@@ -31,7 +31,7 @@
         },
         {
             "name": "gravitee-connector-http",
-            "version": "1.1.0",
+            "version": "1.1.1-SNAPSHOT",
             "since": "3.15.0"
         },
         {


### PR DESCRIPTION
gravitee-io/issues#6967