### PR TITLE
chore: bump version of metrics-reporter policy to 1.2.1

### DIFF
--- a/release.json
+++ b/release.json
@@ -202,7 +202,7 @@
         },
         {
             "name": "gravitee-policy-metrics-reporter",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "since": "3.9.0"
         },
         {


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7194