### PR TITLE
docs: migrate swagger v2 to openapi v3

### DIFF
--- a/upgrades/3.x/3.17.0/README.adoc
+++ b/upgrades/3.x/3.17.0/README.adoc
@@ -1,0 +1,13 @@
+= Upgrade to 3.17.0
+
+== Breaking Changes
+=== Management API Documentation
+
+From this version, APIM's Management API documentation is now using OpenAPI v3 format, instead of the old Swagger v2 format.
+
+As a consequence, the specification of this API is now accessible from:
+
+ * `{host:port}/management/openapi.yaml`
+ * `{host:port}/management/openapi.json`
+
+To allow a smooth transition, the old URL (`{host:port}/management/swagger.json`) will remain available until 3.18.0.

--- a/upgrades/3.x/README.adoc
+++ b/upgrades/3.x/README.adoc
@@ -2,6 +2,8 @@
 
 ifdef::env-github[]
 
+include::3.17.0/README.adoc[leveloffset=+1]
+
 include::3.16.0/README.adoc[leveloffset=+1]
 
 include::3.15.0/README.adoc[leveloffset=+1]
@@ -92,6 +94,8 @@ You may be required to perform manual actions as part of the upgrade.
 
 WARNING: Be sure to run scripts on the correct database since `gravitee` is not always the default database!
 Check your db name by running `show dbs;`
+
+include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.17.0/README.adoc[leveloffset=+1]
 
 include::https://raw.githubusercontent.com/gravitee-io/release/master/upgrades/3.x/3.16.0/README.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6224

## Before merging

Need to discuss if we remove `swagger.json` directly in this version or not ?