### PR TITLE
chore: bump ssl-enforcement policy to 1.2.1

### DIFF
--- a/release.json
+++ b/release.json
@@ -306,7 +306,7 @@
         },
         {
             "name": "gravitee-policy-ssl-enforcement",
-            "version": "1.2.0"
+            "version": "1.2.1"
         },
         {
             "name": "gravitee-policy-json-threat-protection",


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7276