### PR TITLE
chore: bump resource-oauth2-provider-am to 1.14.2

### DIFF
--- a/release.json
+++ b/release.json
@@ -206,7 +206,7 @@
         },
         {
             "name": "gravitee-resource-oauth2-provider-am",
-            "version": "1.14.1",
+            "version": "1.14.2",
             "since": "3.10.0"
         },
         {


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6454