### PR TITLE
chore: bump gravitee-elasticsearch to 3.8.4-SNAPSHOT

### DIFF
--- a/release.json
+++ b/release.json
@@ -183,7 +183,7 @@
         },
         {
             "name": "gravitee-elasticsearch",
-            "version": "3.8.3",
+            "version": "3.8.4-SNAPSHOT",
             "since": "3.10.11"
         },
         {


### PR DESCRIPTION
gravitee-io/issues#6913