### PR TITLE
Remove `gravitee-resource-oauth2-provider-keycloak`

### DIFF
--- a/release.json
+++ b/release.json
@@ -210,11 +210,6 @@
             "since": "3.10.0"
         },
         {
-            "name": "gravitee-resource-oauth2-provider-keycloak",
-            "version": "1.9.1",
-            "since": "3.10.0"
-        },
-        {
             "name": "gravitee-fetcher-api",
             "version": "1.4.0"
         },


### PR DESCRIPTION
`gravitee-resource-oauth2-provider-keycloak` was in this file only for building purposes and standalone release as it is not included in the APIM bundle, see: https://github.com/gravitee-io/jenkins-scripts/blob/master/src/main/python/package_bundles.py#L56