### PR TITLE
Adapt release.json with gravitee-elasticsearch split - 3.15.x

### DIFF
--- a/release.json
+++ b/release.json
@@ -12,7 +12,7 @@
         },
         {
             "name": "gravitee-api-management",
-            "version": "3.15.8",
+            "version": "3.15.9-SNAPSHOT",
             "since": "3.15.8"
         },
         {

--- a/release.json
+++ b/release.json
@@ -25,6 +25,11 @@
             "since": "3.11.1"
         },
         {
+            "name": "gravitee-common-elasticsearch",
+            "version": "3.12.0",
+            "since": "3.14.0"
+        },
+        {
             "name": "gravitee-connector-api",
             "version": "1.1.0",
             "since": "3.15.0"
@@ -38,11 +43,6 @@
             "name": "gravitee-definition",
             "version": "1.31.1",
             "since": "3.15.0"
-        },
-        {
-            "name": "gravitee-elasticsearch",
-            "version": "3.12.0",
-            "since": "3.14.0"
         },
         {
             "name": "gravitee-expression-language",
@@ -301,6 +301,11 @@
             "since": "3.10.1"
         },
         {
+            "name": "gravitee-reporter-elasticsearch",
+            "version": "3.12.0",
+            "since": "3.14.0"
+        },
+        {
             "name": "gravitee-reporter-file",
             "version": "2.5.0",
             "since": "3.15.0"
@@ -411,6 +416,7 @@
             "gravitee-node"
         ],
         [
+            "gravitee-common-elasticsearch",
             "gravitee-resource-oauth2-provider-api"
         ],
         [
@@ -463,6 +469,7 @@
             "gravitee-policy-http-signature",
             "gravitee-policy-traffic-shadowing",
             "gravitee-policy-metrics-reporter",
+            "gravitee-reporter-elasticsearch",
             "gravitee-reporter-file",
             "gravitee-reporter-kafka",
             "gravitee-reporter-tcp",
@@ -479,8 +486,7 @@
         ],
         [
             "gravitee-policy-ratelimit",
-            "gravitee-policy-apikey",
-            "gravitee-elasticsearch"
+            "gravitee-policy-apikey"
         ]
     ]
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7620

* repository has been merged into APIM repository
* reporter and common are each in their own GH repository