### PR TITLE
use latest version of gravitee-reporter-elasticsearch for ILM support

### DIFF
--- a/release.json
+++ b/release.json
@@ -6,9 +6,28 @@
     "scmHttpUrl": "https://github.com/gravitee-io/",
     "components": [
         {
+            "name": "gravitee-alert-api",
+            "version": "1.7.1",
+            "since": "3.9.0"
+        },
+        {
+            "name": "gravitee-api-management",
+            "version": "3.10.15-SNAPSHOT",
+            "since": "3.10.14"
+        },
+        {
+            "name": "gravitee-cockpit-connectors-ws",
+            "version": "2.0.1"
+        },
+        {
             "name": "gravitee-common",
             "version": "1.20.5",
             "since": "3.8.7"
+        },
+        {
+            "name": "gravitee-common-elasticsearch",
+            "version": "3.8.4",
+            "since": "3.10.11"
         },
         {
             "name": "gravitee-definition",
@@ -16,9 +35,37 @@
             "since": "3.10.9"
         },
         {
-            "name": "gravitee-api-management",
-            "version": "3.10.15-SNAPSHOT",
-            "since": "3.10.14"
+            "name": "gravitee-expression-language",
+            "version": "1.6.3",
+            "since": "3.10.4"
+        },
+        {
+            "name": "gravitee-fetcher-api",
+            "version": "1.4.0"
+        },
+        {
+            "name": "gravitee-fetcher-bitbucket",
+            "version": "1.7.0",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-fetcher-git",
+            "version": "1.7.0"
+        },
+        {
+            "name": "gravitee-fetcher-github",
+            "version": "1.6.0",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-fetcher-gitlab",
+            "version": "1.11.0",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-fetcher-http",
+            "version": "1.12.0",
+            "since": "3.10.0"
         },
         {
             "name": "gravitee-gateway-api",
@@ -28,241 +75,6 @@
         {
             "name": "gravitee-identityprovider-api",
             "version": "1.0.0"
-        },
-        {
-            "name": "gravitee-plugin",
-            "version": "1.18.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-policy-api",
-            "version": "1.11.0",
-            "since": "3.9.0"
-        },
-        {
-            "name": "gravitee-policy-apikey",
-            "version": "2.2.0"
-        },
-        {
-            "name": "gravitee-policy-ratelimit",
-            "version": "1.13.2",
-            "since": "3.5.21"
-        },
-        {
-            "name": "gravitee-policy-request-content-limit",
-            "version": "1.7.0"
-        },
-        {
-            "name": "gravitee-policy-transformheaders",
-            "version": "1.8.2",
-            "since": "3.5.21"
-        },
-        {
-            "name": "gravitee-policy-rest-to-soap",
-            "version": "1.12.0",
-            "since": "3.7.0"
-        },
-        {
-            "name": "gravitee-policy-transformqueryparams",
-            "version": "1.6.0"
-        },
-        {
-            "name": "gravitee-policy-ipfiltering",
-            "version": "1.8.0"
-        },
-        {
-            "name": "gravitee-policy-mock",
-            "version": "1.12.0"
-        },
-        {
-            "name": "gravitee-policy-cache",
-            "version": "1.13.1",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-policy-xslt",
-            "version": "1.6.1"
-        },
-        {
-            "name": "gravitee-policy-xml-json",
-            "version": "1.7.1"
-        },
-        {
-            "name": "gravitee-policy-oauth2",
-            "version": "1.18.0",
-            "since": "3.9.0"
-        },
-        {
-            "name": "gravitee-policy-html-json",
-            "version": "1.6.0"
-        },
-        {
-            "name": "gravitee-policy-groovy",
-            "version": "1.15.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-policy-dynamic-routing",
-            "version": "1.11.1",
-            "since": "3.5.21"
-        },
-        {
-            "name": "gravitee-policy-jwt",
-            "version": "1.20.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-policy-override-http-method",
-            "version": "1.3.0"
-        },
-        {
-            "name": "gravitee-policy-request-validation",
-            "version": "1.12.0"
-        },
-        {
-            "name": "gravitee-policy-resource-filtering",
-            "version": "1.8.0"
-        },
-        {
-            "name": "gravitee-policy-json-to-json",
-            "version": "1.6.1"
-        },
-        {
-            "name": "gravitee-policy-json-xml",
-            "version": "1.0.1"
-        },
-        {
-            "name": "gravitee-policy-keyless",
-            "version": "1.4.0",
-            "since": "3.9.0"
-        },
-        {
-            "name": "gravitee-policy-openid-connect-userinfo",
-            "version": "1.4.0"
-        },
-        {
-            "name": "gravitee-policy-latency",
-            "version": "1.4.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-policy-assign-content",
-            "version": "1.6.0"
-        },
-        {
-            "name": "gravitee-policy-jws",
-            "version": "1.3.2"
-        },
-        {
-            "name": "gravitee-policy-callout-http",
-            "version": "1.13.0"
-        },
-        {
-            "name": "gravitee-policy-assign-attributes",
-            "version": "1.5.0"
-        },
-        {
-            "name": "gravitee-policy-metrics-reporter",
-            "version": "1.1.1",
-            "since": "3.9.0"
-        },
-        {
-            "name": "gravitee-reporter-api",
-            "version": "1.21.0",
-            "since": "3.10.1"
-        },
-        {
-            "name": "gravitee-reporter-file",
-            "version": "2.4.3",
-            "since": "3.10.6"
-        },
-        {
-            "name": "gravitee-reporter-tcp",
-            "version": "1.3.3",
-            "since": "3.10.6"
-        },
-        {
-            "name": "gravitee-common-elasticsearch",
-            "version": "3.8.4",
-            "since": "3.10.11"
-        },
-        {
-            "name": "gravitee-reporter-elasticsearch",
-            "version": "3.8.4",
-            "since": "3.10.11"
-        },
-        {
-            "name": "gravitee-resource-api",
-            "version": "1.1.0"
-        },
-        {
-            "name": "gravitee-resource-cache",
-            "version": "1.6.2",
-            "since": "3.5.21"
-        },
-        {
-            "name": "gravitee-resource-oauth2-provider-api",
-            "version": "1.3.0"
-        },
-        {
-            "name": "gravitee-resource-oauth2-provider-generic",
-            "version": "1.16.1",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-resource-oauth2-provider-am",
-            "version": "1.14.2",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-fetcher-api",
-            "version": "1.4.0"
-        },
-        {
-            "name": "gravitee-fetcher-http",
-            "version": "1.12.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-fetcher-git",
-            "version": "1.7.0"
-        },
-        {
-            "name": "gravitee-fetcher-gitlab",
-            "version": "1.11.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-fetcher-bitbucket",
-            "version": "1.7.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-fetcher-github",
-            "version": "1.6.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-expression-language",
-            "version": "1.6.3",
-            "since": "3.10.4"
-        },
-        {
-            "name": "gravitee-policy-url-rewriting",
-            "version": "1.4.0"
-        },
-        {
-            "name": "gravitee-policy-json-validation",
-            "version": "1.6.1"
-        },
-        {
-            "name": "gravitee-policy-xml-validation",
-            "version": "1.1.0"
-        },
-        {
-            "name": "gravitee-reporter-kafka",
-            "version": "1.3.0",
-            "since": "3.10.6"
         },
         {
             "name": "gravitee-node",
@@ -279,9 +91,246 @@
             "version": "1.3.0"
         },
         {
-            "name": "gravitee-alert-api",
-            "version": "1.7.1",
+            "name": "gravitee-plugin",
+            "version": "1.18.0",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-policy-api",
+            "version": "1.11.0",
             "since": "3.9.0"
+        },
+        {
+            "name": "gravitee-policy-apikey",
+            "version": "2.2.0"
+        },
+        {
+            "name": "gravitee-policy-assign-attributes",
+            "version": "1.5.0"
+        },
+        {
+            "name": "gravitee-policy-assign-content",
+            "version": "1.6.0"
+        },
+        {
+            "name": "gravitee-policy-cache",
+            "version": "1.13.1",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-policy-callout-http",
+            "version": "1.13.0"
+        },
+        {
+            "name": "gravitee-policy-dynamic-routing",
+            "version": "1.11.1",
+            "since": "3.5.21"
+        },
+        {
+            "name": "gravitee-policy-generate-jwt",
+            "version": "1.5.0"
+        },
+        {
+            "name": "gravitee-policy-groovy",
+            "version": "1.15.0",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-policy-html-json",
+            "version": "1.6.0"
+        },
+        {
+            "name": "gravitee-policy-http-signature",
+            "version": "1.3.0",
+            "since": "3.7.0"
+        },
+        {
+            "name": "gravitee-policy-ipfiltering",
+            "version": "1.8.0"
+        },
+        {
+            "name": "gravitee-policy-json-threat-protection",
+            "version": "1.2.3",
+            "since": "3.10.1"
+        },
+        {
+            "name": "gravitee-policy-json-to-json",
+            "version": "1.6.1"
+        },
+        {
+            "name": "gravitee-policy-json-validation",
+            "version": "1.6.1"
+        },
+        {
+            "name": "gravitee-policy-json-xml",
+            "version": "1.0.1"
+        },
+        {
+            "name": "gravitee-policy-jws",
+            "version": "1.3.2"
+        },
+        {
+            "name": "gravitee-policy-jwt",
+            "version": "1.20.0",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-policy-keyless",
+            "version": "1.4.0",
+            "since": "3.9.0"
+        },
+        {
+            "name": "gravitee-policy-latency",
+            "version": "1.4.0",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-policy-metrics-reporter",
+            "version": "1.1.1",
+            "since": "3.9.0"
+        },
+        {
+            "name": "gravitee-policy-mock",
+            "version": "1.12.0"
+        },
+        {
+            "name": "gravitee-policy-oauth2",
+            "version": "1.18.0",
+            "since": "3.9.0"
+        },
+        {
+            "name": "gravitee-policy-openid-connect-userinfo",
+            "version": "1.4.0"
+        },
+        {
+            "name": "gravitee-policy-override-http-method",
+            "version": "1.3.0"
+        },
+        {
+            "name": "gravitee-policy-ratelimit",
+            "version": "1.13.2",
+            "since": "3.5.21"
+        },
+        {
+            "name": "gravitee-policy-regex-threat-protection",
+            "version": "1.2.1"
+        },
+        {
+            "name": "gravitee-policy-request-content-limit",
+            "version": "1.7.0"
+        },
+        {
+            "name": "gravitee-policy-request-validation",
+            "version": "1.12.0"
+        },
+        {
+            "name": "gravitee-policy-resource-filtering",
+            "version": "1.8.0"
+        },
+        {
+            "name": "gravitee-policy-rest-to-soap",
+            "version": "1.12.0",
+            "since": "3.7.0"
+        },
+        {
+            "name": "gravitee-policy-retry",
+            "version": "2.0.0"
+        },
+        {
+            "name": "gravitee-policy-role-based-access-control",
+            "version": "1.1.0"
+        },
+        {
+            "name": "gravitee-policy-ssl-enforcement",
+            "version": "1.2.1"
+        },
+        {
+            "name": "gravitee-policy-traffic-shadowing",
+            "version": "1.1.0",
+            "since": "3.8.0"
+        },
+        {
+            "name": "gravitee-policy-transformheaders",
+            "version": "1.8.2",
+            "since": "3.5.21"
+        },
+        {
+            "name": "gravitee-policy-transformqueryparams",
+            "version": "1.6.0"
+        },
+        {
+            "name": "gravitee-policy-url-rewriting",
+            "version": "1.4.0"
+        },
+        {
+            "name": "gravitee-policy-xml-json",
+            "version": "1.7.1"
+        },
+        {
+            "name": "gravitee-policy-xml-threat-protection",
+            "version": "1.2.2",
+            "since": "3.9.4"
+        },
+        {
+            "name": "gravitee-policy-xml-validation",
+            "version": "1.1.0"
+        },
+        {
+            "name": "gravitee-policy-xslt",
+            "version": "1.6.1"
+        },
+        {
+            "name": "gravitee-reporter-api",
+            "version": "1.21.0",
+            "since": "3.10.1"
+        },
+        {
+            "name": "gravitee-reporter-elasticsearch",
+            "version": "3.8.4",
+            "since": "3.10.11"
+        },
+        {
+            "name": "gravitee-reporter-file",
+            "version": "2.4.3",
+            "since": "3.10.6"
+        },
+        {
+            "name": "gravitee-reporter-kafka",
+            "version": "1.3.0",
+            "since": "3.10.6"
+        },
+        {
+            "name": "gravitee-reporter-tcp",
+            "version": "1.3.3",
+            "since": "3.10.6"
+        },
+        {
+            "name": "gravitee-resource-api",
+            "version": "1.1.0"
+        },
+        {
+            "name": "gravitee-resource-cache",
+            "version": "1.6.2",
+            "since": "3.5.21"
+        },
+        {
+            "name": "gravitee-resource-cache-provider-api",
+            "version": "1.1.0",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-resource-oauth2-provider-am",
+            "version": "1.14.2",
+            "since": "3.10.0"
+        },
+        {
+            "name": "gravitee-resource-oauth2-provider-api",
+            "version": "1.3.0"
+        },
+        {
+            "name": "gravitee-resource-oauth2-provider-generic",
+            "version": "1.16.1",
+            "since": "3.10.0"
         },
         {
             "name": "gravitee-service-discovery-api",
@@ -293,57 +342,8 @@
             "since": "3.10.0"
         },
         {
-            "name": "gravitee-policy-generate-jwt",
-            "version": "1.5.0"
-        },
-        {
             "name": "gravitee-service-discovery-eureka",
             "version": "1.1.1"
-        },
-        {
-            "name": "gravitee-policy-role-based-access-control",
-            "version": "1.1.0"
-        },
-        {
-            "name": "gravitee-policy-ssl-enforcement",
-            "version": "1.2.1"
-        },
-        {
-            "name": "gravitee-policy-json-threat-protection",
-            "version": "1.2.3",
-            "since": "3.10.1"
-        },
-        {
-            "name": "gravitee-policy-regex-threat-protection",
-            "version": "1.2.1"
-        },
-        {
-            "name": "gravitee-policy-xml-threat-protection",
-            "version": "1.2.2",
-            "since": "3.9.4"
-        },
-        {
-            "name": "gravitee-policy-retry",
-            "version": "2.0.0"
-        },
-        {
-            "name": "gravitee-policy-http-signature",
-            "version": "1.3.0",
-            "since": "3.7.0"
-        },
-        {
-            "name": "gravitee-cockpit-connectors-ws",
-            "version": "2.0.1"
-        },
-        {
-            "name": "gravitee-policy-traffic-shadowing",
-            "version": "1.1.0",
-            "since": "3.8.0"
-        },
-        {
-            "name": "gravitee-resource-cache-provider-api",
-            "version": "1.1.0",
-            "since": "3.10.0"
         },
         {
             "name": "gravitee-tracing-api",

--- a/release.json
+++ b/release.json
@@ -6,11 +6,6 @@
     "scmHttpUrl": "https://github.com/gravitee-io/",
     "components": [
         {
-            "name": "gravitee-alert-api",
-            "version": "1.7.1",
-            "since": "3.9.0"
-        },
-        {
             "name": "gravitee-api-management",
             "version": "3.10.15-SNAPSHOT",
             "since": "3.10.14"
@@ -18,30 +13,6 @@
         {
             "name": "gravitee-cockpit-connectors-ws",
             "version": "2.0.1"
-        },
-        {
-            "name": "gravitee-common",
-            "version": "1.20.5",
-            "since": "3.8.7"
-        },
-        {
-            "name": "gravitee-common-elasticsearch",
-            "version": "3.8.4",
-            "since": "3.10.11"
-        },
-        {
-            "name": "gravitee-definition",
-            "version": "1.28.2",
-            "since": "3.10.9"
-        },
-        {
-            "name": "gravitee-expression-language",
-            "version": "1.6.3",
-            "since": "3.10.4"
-        },
-        {
-            "name": "gravitee-fetcher-api",
-            "version": "1.4.0"
         },
         {
             "name": "gravitee-fetcher-bitbucket",
@@ -66,39 +37,6 @@
             "name": "gravitee-fetcher-http",
             "version": "1.12.0",
             "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-gateway-api",
-            "version": "1.27.3",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-identityprovider-api",
-            "version": "1.0.0"
-        },
-        {
-            "name": "gravitee-node",
-            "version": "1.16.5",
-            "since": "3.10.11"
-        },
-        {
-            "name": "gravitee-notifier-api",
-            "version": "1.4.1",
-            "since": "3.9.0"
-        },
-        {
-            "name": "gravitee-notifier-email",
-            "version": "1.3.0"
-        },
-        {
-            "name": "gravitee-plugin",
-            "version": "1.18.0",
-            "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-policy-api",
-            "version": "1.11.0",
-            "since": "3.9.0"
         },
         {
             "name": "gravitee-policy-apikey",
@@ -280,11 +218,6 @@
             "version": "1.6.1"
         },
         {
-            "name": "gravitee-reporter-api",
-            "version": "1.21.0",
-            "since": "3.10.1"
-        },
-        {
             "name": "gravitee-reporter-elasticsearch",
             "version": "3.8.4",
             "since": "3.10.11"
@@ -305,18 +238,9 @@
             "since": "3.10.6"
         },
         {
-            "name": "gravitee-resource-api",
-            "version": "1.1.0"
-        },
-        {
             "name": "gravitee-resource-cache",
             "version": "1.6.2",
             "since": "3.5.21"
-        },
-        {
-            "name": "gravitee-resource-cache-provider-api",
-            "version": "1.1.0",
-            "since": "3.10.0"
         },
         {
             "name": "gravitee-resource-oauth2-provider-am",
@@ -324,17 +248,9 @@
             "since": "3.10.0"
         },
         {
-            "name": "gravitee-resource-oauth2-provider-api",
-            "version": "1.3.0"
-        },
-        {
             "name": "gravitee-resource-oauth2-provider-generic",
             "version": "1.16.1",
             "since": "3.10.0"
-        },
-        {
-            "name": "gravitee-service-discovery-api",
-            "version": "1.1.1"
         },
         {
             "name": "gravitee-service-discovery-consul",
@@ -346,117 +262,12 @@
             "version": "1.1.1"
         },
         {
-            "name": "gravitee-tracing-api",
-            "version": "1.0.0",
-            "since": "3.10.0"
-        },
-        {
             "name": "gravitee-tracer-jaeger",
             "version": "1.0.0",
             "since": "3.10.0"
         }
     ],
     "buildDependencies": [
-        [
-            "gravitee-common"
-        ],
-        [
-            "gravitee-expression-language",
-            "gravitee-service-discovery-api",
-            "gravitee-notifier-api"
-        ],
-        [
-            "gravitee-service-discovery-consul",
-            "gravitee-service-discovery-eureka"
-        ],
-        [
-            "gravitee-reporter-api",
-            "gravitee-resource-api",
-            "gravitee-definition",
-            "gravitee-fetcher-api",
-            "gravitee-alert-api",
-            "gravitee-notifier-email",
-            "gravitee-identityprovider-api",
-            "gravitee-cockpit-api",
-            "gravitee-tracing-api"
-        ],
-        [
-            "gravitee-gateway-api"
-        ],
-        [
-            "gravitee-policy-api",
-            "gravitee-resource-cache-provider-api"
-        ],
-        [
-            "gravitee-plugin"
-        ],
-        [
-            "gravitee-node"
-        ],
-        [
-            "gravitee-common-elasticsearch",
-            "gravitee-resource-oauth2-provider-api"
-        ],
-        [
-            "gravitee-resource-cache",
-            "gravitee-resource-oauth2-provider-generic",
-            "gravitee-resource-oauth2-provider-am",
-            "gravitee-resource-oauth2-provider-keycloak"
-        ],
-        [
-            "gravitee-policy-apikey",
-            "gravitee-policy-ratelimit",
-            "gravitee-policy-request-content-limit",
-            "gravitee-policy-transformheaders",
-            "gravitee-policy-rest-to-soap",
-            "gravitee-policy-transformqueryparams",
-            "gravitee-policy-ipfiltering",
-            "gravitee-policy-mock",
-            "gravitee-policy-cache",
-            "gravitee-policy-xslt",
-            "gravitee-policy-xml-json",
-            "gravitee-policy-oauth2",
-            "gravitee-policy-html-json",
-            "gravitee-policy-groovy",
-            "gravitee-policy-dynamic-routing",
-            "gravitee-policy-jwt",
-            "gravitee-policy-resource-filtering",
-            "gravitee-policy-json-to-json",
-            "gravitee-policy-json-xml",
-            "gravitee-policy-keyless",
-            "gravitee-policy-override-http-method",
-            "gravitee-policy-request-validation",
-            "gravitee-policy-openid-connect-userinfo",
-            "gravitee-policy-latency",
-            "gravitee-policy-assign-content",
-            "gravitee-policy-jws",
-            "gravitee-policy-url-rewriting",
-            "gravitee-policy-json-validation",
-            "gravitee-policy-xml-validation",
-            "gravitee-policy-callout-http",
-            "gravitee-policy-generate-jwt",
-            "gravitee-policy-assign-attributes",
-            "gravitee-policy-role-based-access-control",
-            "gravitee-policy-ssl-enforcement",
-            "gravitee-policy-json-threat-protection",
-            "gravitee-policy-regex-threat-protection",
-            "gravitee-policy-xml-threat-protection",
-            "gravitee-policy-retry",
-            "gravitee-policy-http-signature",
-            "gravitee-policy-traffic-shadowing",
-            "gravitee-policy-metrics-reporter",
-            "gravitee-reporter-elasticsearch",
-            "gravitee-reporter-file",
-            "gravitee-reporter-kafka",
-            "gravitee-reporter-tcp",
-            "gravitee-fetcher-http",
-            "gravitee-fetcher-git",
-            "gravitee-fetcher-gitlab",
-            "gravitee-fetcher-bitbucket",
-            "gravitee-fetcher-github",
-            "gravitee-cockpit-connectors",
-            "gravitee-tracer-jaeger"
-        ],
         [
             "gravitee-api-management"
         ]

--- a/release.json
+++ b/release.json
@@ -199,7 +199,7 @@
         },
         {
             "name": "gravitee-reporter-elasticsearch",
-            "version": "3.8.4"
+            "version": "3.8.5"
         },
         {
             "name": "gravitee-reporter-file",

--- a/release.json
+++ b/release.json
@@ -7,8 +7,7 @@
     "components": [
         {
             "name": "gravitee-api-management",
-            "version": "3.10.15-SNAPSHOT",
-            "since": "3.10.14"
+            "version": "3.10.15-SNAPSHOT"
         },
         {
             "name": "gravitee-cockpit-connectors-ws",
@@ -16,8 +15,7 @@
         },
         {
             "name": "gravitee-fetcher-bitbucket",
-            "version": "1.7.0",
-            "since": "3.10.0"
+            "version": "1.7.0"
         },
         {
             "name": "gravitee-fetcher-git",
@@ -25,18 +23,15 @@
         },
         {
             "name": "gravitee-fetcher-github",
-            "version": "1.6.0",
-            "since": "3.10.0"
+            "version": "1.6.0"
         },
         {
             "name": "gravitee-fetcher-gitlab",
-            "version": "1.11.0",
-            "since": "3.10.0"
+            "version": "1.11.0"
         },
         {
             "name": "gravitee-fetcher-http",
-            "version": "1.12.0",
-            "since": "3.10.0"
+            "version": "1.12.0"
         },
         {
             "name": "gravitee-policy-apikey",
@@ -52,8 +47,7 @@
         },
         {
             "name": "gravitee-policy-cache",
-            "version": "1.13.1",
-            "since": "3.10.0"
+            "version": "1.13.1"
         },
         {
             "name": "gravitee-policy-callout-http",
@@ -61,8 +55,7 @@
         },
         {
             "name": "gravitee-policy-dynamic-routing",
-            "version": "1.11.1",
-            "since": "3.5.21"
+            "version": "1.11.1"
         },
         {
             "name": "gravitee-policy-generate-jwt",
@@ -70,8 +63,7 @@
         },
         {
             "name": "gravitee-policy-groovy",
-            "version": "1.15.0",
-            "since": "3.10.0"
+            "version": "1.15.0"
         },
         {
             "name": "gravitee-policy-html-json",
@@ -79,8 +71,7 @@
         },
         {
             "name": "gravitee-policy-http-signature",
-            "version": "1.3.0",
-            "since": "3.7.0"
+            "version": "1.3.0"
         },
         {
             "name": "gravitee-policy-ipfiltering",
@@ -88,8 +79,7 @@
         },
         {
             "name": "gravitee-policy-json-threat-protection",
-            "version": "1.2.3",
-            "since": "3.10.1"
+            "version": "1.2.3"
         },
         {
             "name": "gravitee-policy-json-to-json",
@@ -109,23 +99,19 @@
         },
         {
             "name": "gravitee-policy-jwt",
-            "version": "1.20.0",
-            "since": "3.10.0"
+            "version": "1.20.0"
         },
         {
             "name": "gravitee-policy-keyless",
-            "version": "1.4.0",
-            "since": "3.9.0"
+            "version": "1.4.0"
         },
         {
             "name": "gravitee-policy-latency",
-            "version": "1.4.0",
-            "since": "3.10.0"
+            "version": "1.4.0"
         },
         {
             "name": "gravitee-policy-metrics-reporter",
-            "version": "1.1.1",
-            "since": "3.9.0"
+            "version": "1.1.1"
         },
         {
             "name": "gravitee-policy-mock",
@@ -133,8 +119,7 @@
         },
         {
             "name": "gravitee-policy-oauth2",
-            "version": "1.18.0",
-            "since": "3.9.0"
+            "version": "1.18.0"
         },
         {
             "name": "gravitee-policy-openid-connect-userinfo",
@@ -146,8 +131,7 @@
         },
         {
             "name": "gravitee-policy-ratelimit",
-            "version": "1.13.2",
-            "since": "3.5.21"
+            "version": "1.13.2"
         },
         {
             "name": "gravitee-policy-regex-threat-protection",
@@ -167,8 +151,7 @@
         },
         {
             "name": "gravitee-policy-rest-to-soap",
-            "version": "1.12.0",
-            "since": "3.7.0"
+            "version": "1.12.0"
         },
         {
             "name": "gravitee-policy-retry",
@@ -184,13 +167,11 @@
         },
         {
             "name": "gravitee-policy-traffic-shadowing",
-            "version": "1.1.0",
-            "since": "3.8.0"
+            "version": "1.1.0"
         },
         {
             "name": "gravitee-policy-transformheaders",
-            "version": "1.8.2",
-            "since": "3.5.21"
+            "version": "1.8.2"
         },
         {
             "name": "gravitee-policy-transformqueryparams",
@@ -206,8 +187,7 @@
         },
         {
             "name": "gravitee-policy-xml-threat-protection",
-            "version": "1.2.2",
-            "since": "3.9.4"
+            "version": "1.2.2"
         },
         {
             "name": "gravitee-policy-xml-validation",
@@ -219,43 +199,35 @@
         },
         {
             "name": "gravitee-reporter-elasticsearch",
-            "version": "3.8.4",
-            "since": "3.10.11"
+            "version": "3.8.4"
         },
         {
             "name": "gravitee-reporter-file",
-            "version": "2.4.3",
-            "since": "3.10.6"
+            "version": "2.4.3"
         },
         {
             "name": "gravitee-reporter-kafka",
-            "version": "1.3.0",
-            "since": "3.10.6"
+            "version": "1.3.0"
         },
         {
             "name": "gravitee-reporter-tcp",
-            "version": "1.3.3",
-            "since": "3.10.6"
+            "version": "1.3.3"
         },
         {
             "name": "gravitee-resource-cache",
-            "version": "1.6.2",
-            "since": "3.5.21"
+            "version": "1.6.2"
         },
         {
             "name": "gravitee-resource-oauth2-provider-am",
-            "version": "1.14.2",
-            "since": "3.10.0"
+            "version": "1.14.2"
         },
         {
             "name": "gravitee-resource-oauth2-provider-generic",
-            "version": "1.16.1",
-            "since": "3.10.0"
+            "version": "1.16.1"
         },
         {
             "name": "gravitee-service-discovery-consul",
-            "version": "1.3.0",
-            "since": "3.10.0"
+            "version": "1.3.0"
         },
         {
             "name": "gravitee-service-discovery-eureka",
@@ -263,8 +235,7 @@
         },
         {
             "name": "gravitee-tracer-jaeger",
-            "version": "1.0.0",
-            "since": "3.10.0"
+            "version": "1.0.0"
         }
     ],
     "buildDependencies": [


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7110

**Description**
use latest version of gravitee-reporter-elasticsearch for ILM support
+
some simplification for the `release.json` file