### PR TITLE
fix: bump gravitee-resource-oauth2-provider-generic

### DIFF
--- a/release.json
+++ b/release.json
@@ -223,7 +223,7 @@
         },
         {
             "name": "gravitee-resource-oauth2-provider-generic",
-            "version": "1.16.1"
+            "version": "1.16.2"
         },
         {
             "name": "gravitee-service-discovery-consul",


### PR DESCRIPTION
bump `gravitee-resource-oauth2-provider-generic`

gravitee-io/issues#7258