### PR TITLE
chore: bump connector-http to 1.1.9

### DIFF
--- a/release.json
+++ b/release.json
@@ -15,7 +15,7 @@
         },
         {
             "name": "gravitee-connector-http",
-            "version": "1.1.5"
+            "version": "1.1.9"
         },
         {
             "name": "gravitee-fetcher-bitbucket",


### PR DESCRIPTION
gravitee-io/issues#7930